### PR TITLE
Add automated deployment endpoint and root API status response

### DIFF
--- a/bookstore/urls.py
+++ b/bookstore/urls.py
@@ -1,28 +1,41 @@
 """
 URL configuration for bookstore project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 import debug_toolbar
 from django.contrib import admin
 from django.urls import path, re_path, include
 from rest_framework.authtoken.views import obtain_auth_token
+from django.http import JsonResponse, HttpResponse
+import os
+import subprocess
+
+def home(request):
+    return JsonResponse({
+        "message": "🚀 Welcome to the Bookstore API!",
+        "status": "running",
+        "documentation": "https://github.com/Bruno-Alvez/bookstore"
+    })
+
+def update_server(request):
+    if request.method == "POST":
+        project_path = "/home/brunoalvesdev/bookstore"
+        os.chdir(project_path)
+        result = subprocess.run(["git", "pull"], capture_output=True, text=True)
+
+        wsgi_path = "/var/www/brunoalvesdev_pythonanywhere_com_wsgi.py"
+        os.utime(wsgi_path, None)
+
+        return HttpResponse(f"Updated:\n{result.stdout}")
+    else:
+        return HttpResponse("Only POST requests are allowed.", status=405)
 
 urlpatterns = [
+    path('', home),
     path('__debug__/', include(debug_toolbar.urls)),
     path("admin/", admin.site.urls),
     re_path("bookstore/(?P<version>(v1|v2))/", include("order.urls")),
     re_path("bookstore/(?P<version>(v1|v2))/", include("product.urls")),
-    path('api-toke-auth/', obtain_auth_token, name='api_token_auth')
+    path('api-token-auth/', obtain_auth_token, name='api_token_auth'),
+    path('update_server/', update_server),
 ]

--- a/bookstore/views.py
+++ b/bookstore/views.py
@@ -1,0 +1,31 @@
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+import git
+import os
+
+
+@csrf_exempt
+def update(request):
+    """
+    View para automatizar o deploy via GitHub webhook (POST).
+    Realiza git pull no repositório e atualiza o WSGI para refletir mudanças.
+    """
+    if request.method == "POST":
+        try:
+            repo = git.Repo('/home/brunoalvesdev/bookstore')
+            origin = repo.remotes.origin
+            origin.pull()
+
+            os.utime('/var/www/brunoalvesdev_pythonanywhere_com_wsgi.py', None)
+
+            return HttpResponse("✅ Código atualizado com sucesso via GitHub.")
+        except Exception as e:
+            return HttpResponse(f"❌ Falha ao atualizar o código: {str(e)}", status=500)
+    return HttpResponse("Apenas requisições POST são permitidas.", status=405)
+
+
+def home(request):
+    """
+    View principal da API. Responde na raiz (/) com uma mensagem de status.
+    """
+    return HttpResponse("📚 Bookstore API is running! Explore os endpoints disponíveis.")


### PR DESCRIPTION
### Summary

This PR introduces two key improvements:

- A new root (`/`) endpoint that returns a JSON response confirming that the API is up and running.
- A new route `/update_server/` that allows automated code deployment on PythonAnywhere via a POST request using Git.

### Changes

- Created a `home` view that returns API status and documentation URL.
- Created an `update_server` view that pulls the latest code and refreshes the WSGI file.
- Registered both views in the main `urls.py`.

### Motivation

These changes improve the API onboarding experience and eliminate the need for manual code pulls on the PythonAnywhere dashboard after each push to GitHub.
